### PR TITLE
type variable T isn't actually used, so can never be inferred at call site

### DIFF
--- a/src/seal.rs
+++ b/src/seal.rs
@@ -194,7 +194,7 @@ pub fn seal_commit_phase1<T: AsRef<Path>>(
     }
 }
 
-pub fn seal_commit_phase2<T: AsRef<Path>>(
+pub fn seal_commit_phase2(
     phase1_output: SealCommitPhase1Output,
     prover_id: ProverId,
     sector_id: SectorId,

--- a/src/seal.rs
+++ b/src/seal.rs
@@ -91,7 +91,7 @@ where
     }
 }
 
-pub fn seal_pre_commit_phase2<R, S, T>(
+pub fn seal_pre_commit_phase2<R, S>(
     phase1_output: SealPreCommitPhase1Output,
     cache_path: R,
     out_path: S,


### PR DESCRIPTION
The unused type variable means that I have to do the following:

```
match filecoin_proofs_api::seal::seal_pre_commit_phase2::<PathBuf, PathBuf, ()>(
    spcp1o,
    c_str_to_pbuf(cache_dir_path),
    c_str_to_pbuf(sealed_sector_path),
) {
```

and that is annoying. This PR eliminates that unused type variable.