### PR TITLE
feat: return the RegisteredPoStProof from generate_poast

### DIFF
--- a/src/post.rs
+++ b/src/post.rs
@@ -55,9 +55,11 @@ pub fn generate_post(
         prover_id,
     )?;
 
-    let post_tuples = posts_v1.into_iter().zip(iter::repeat(rpp_v1)).map(|(snark_proof, rpp)| {
-        (rpp, snark_proof)
-    }).collect();
+    let post_tuples = posts_v1
+        .into_iter()
+        .zip(iter::repeat(rpp_v1))
+        .map(|(snark_proof, rpp)| (rpp, snark_proof))
+        .collect();
 
     // once there are multiple versions, merge them before returning
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,8 +8,6 @@ use crate::{Commitment, RegisteredPoStProof};
 pub struct PrivateReplicaInfo {
     /// The version of this replica.
     pub(crate) registered_proof: RegisteredPoStProof,
-    /// Path to the replica.
-    pub(crate) access: String,
     /// The replica commitment.
     pub(crate) comm_r: Commitment,
     /// Contains sector-specific (e.g. merkle trees) assets
@@ -21,14 +19,12 @@ pub struct PrivateReplicaInfo {
 impl PrivateReplicaInfo {
     pub fn new(
         registered_proof: RegisteredPoStProof,
-        access: String,
         comm_r: Commitment,
         cache_dir: PathBuf,
         replica_path: PathBuf,
     ) -> Self {
         PrivateReplicaInfo {
             registered_proof,
-            access,
             comm_r,
             cache_dir,
             replica_path,


### PR DESCRIPTION
## Why does this PR exist?

The `generate_post` function has a parameter `replicas: &BTreeMap<SectorId, PrivateReplicaInfo>`. Each `PrivateReplicaInfo` has its own `RegisteredPoStProof`, and so the returned proofs need to indicate which `RegisteredPoStProof` was used to generate them.