### PR TITLE
Update to reflect new location of Candidate type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@ mod types;
 pub use crate::registry::{RegisteredPoStProof, RegisteredSealProof};
 pub use crate::types::{PrivateReplicaInfo, PublicReplicaInfo};
 
-pub use filecoin_proofs_v1::storage_proofs::election_post::Candidate;
 pub use filecoin_proofs_v1::storage_proofs::fr32;
+pub use filecoin_proofs_v1::storage_proofs::post::election::Candidate;
 pub use filecoin_proofs_v1::storage_proofs::sector::SectorId;
 pub use filecoin_proofs_v1::types::{
     ChallengeSeed, Commitment, PaddedBytesAmount, PieceInfo, ProverId, Ticket, UnpaddedByteIndex,


### PR DESCRIPTION
## Why's this PR exist?

The `Candidate` type moved modules on me.

## What's in this PR?

I now import it from its new location.