### PR TITLE
Use correct fauxrep shape type parameters per sector size.

### DIFF
--- a/src/seal.rs
+++ b/src/seal.rs
@@ -578,63 +578,63 @@ pub fn fauxrep<R: AsRef<Path>, S: AsRef<Path>>(
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_4_KIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape4KiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_16_KIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape16KiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_32_KIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape32KiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_8_MIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape8MiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_16_MIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape16MiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_512_MIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape512MiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_1_GIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape1GiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_32_GIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape32GiB>(
                 config,
                 cache_path,
                 replica_path,
             )
         }
         filecoin_proofs_v1::constants::SECTOR_SIZE_64_GIB => {
-            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape2KiB>(
+            filecoin_proofs_v1::fauxrep::<_, _, filecoin_proofs_v1::constants::SectorShape64GiB>(
                 config,
                 cache_path,
                 replica_path,


### PR DESCRIPTION
This PR corrects an oversight in the first draft. When unrolling the `with_shape!` macro to insert appropriate shape type parameters based on sector size, the same type `SectorShape2KiB` was used for every sector size. Instead, use the correct shape for each sector size.