### PR TITLE
chore: don't start a new dev version after a release

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,3 @@
+pre-release-commit-message = "chore({{crate_name}}): release {{version}}"
+pro-release-commit-message = "chore({{crate_name}}): starting development cycle for {{next_version}}"
+no-dev-version = true


### PR DESCRIPTION
Also use "chore" as prefix for releases in case we start doing
automated changelogs.