### PR TITLE
feat: export storage proofs errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod types;
 pub use crate::registry::{RegisteredPoStProof, RegisteredSealProof, Version};
 pub use crate::types::{PrivateReplicaInfo, PublicReplicaInfo};
 
+pub use filecoin_proofs_v1::storage_proofs::error::Error as StorageProofsError;
 pub use filecoin_proofs_v1::storage_proofs::fr32;
 pub use filecoin_proofs_v1::storage_proofs::post::election::Candidate;
 pub use filecoin_proofs_v1::storage_proofs::sector::{OrderedSectorSet, SectorId};


### PR DESCRIPTION
This way the FFI has access to specific storage proofs errors.