### PR TITLE
Expose distributed PoSt API from rust-fil-proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+## [5.2.0] - 2020-09-28
+
+- Expose distributed PoSt API from proofs [#41](https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/41)
+
+## [5.1.1] - 2020-09-08
+
+- Export storage proofs errors [#40](https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/40)
+- Replace unwrap usage with expect [#39](https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/39)
+
 ## [5.1.0] - 2020-08-13
 
-- Upgrade filecoin_proofs dependency to v5.1.1
+- Upgrade filecoin_proofs dependency to v5.1.1 [#38](https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/38)
 
 ## [5.0.0] - 2020-08-11
 
@@ -53,7 +62,9 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 - Initial stable release
 
-[Unreleased]: https://github.com/filecoin-project/rust-filecoin-proofs-api/compare/v5.1.0...HEAD
+[Unreleased]: https://github.com/filecoin-project/rust-filecoin-proofs-api/compare/v5.2.0...HEAD
+[5.2.0]: https://github.com/filecoin-project/rust-filecoin-proofs-api/tree/v5.2.0
+[5.1.1]: https://github.com/filecoin-project/rust-filecoin-proofs-api/tree/v5.1.1
 [5.1.0]: https://github.com/filecoin-project/rust-filecoin-proofs-api/tree/v5.1.0
 [5.0.0]: https://github.com/filecoin-project/rust-filecoin-proofs-api/tree/v5.0.0
 [4.0.4]: https://github.com/filecoin-project/rust-filecoin-proofs-api/tree/v4.0.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.26"
+bincode = "1.1.2"
 serde = "1.0.104"
 paired = "0.20.0"
-filecoin-proofs-v1 = { package = "filecoin-proofs", version = "5.1.1" }
+filecoin-proofs-v1 = { package = "filecoin-proofs", version = "5.2.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,4 @@ pub use filecoin_proofs_v1::types::{
     ChallengeSeed, Commitment, PaddedBytesAmount, PieceInfo, PoStType, ProverId, Ticket,
     UnpaddedByteIndex, UnpaddedBytesAmount,
 };
-pub use filecoin_proofs_v1::SnarkProof;
+pub use filecoin_proofs_v1::{FallbackPoStSectorProof, SnarkProof, VanillaProof};

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 
 use crate::{Commitment, RegisteredPoStProof};
 
+// A byte serialized representation of a vanilla proof.
+pub type VanillaProofBytes = Vec<u8>;
+
 /// The minimal information required about a replica, in order to be able to generate
 /// a PoSt over it.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
NOTE: This points to a branch on proofs, as it depends on https://github.com/filecoin-project/rust-fil-proofs/pull/1283