### PR TITLE
chore: remove the dependency on storage-proofs-porep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
 
   test_darwin:
     macos:
-      xcode: "12.5.0"
+      xcode: "13.4.1"
     working_directory: ~/crate
     resource_class: large
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,9 @@ filecoin-proofs-v1 = { package = "filecoin-proofs", version = "~12.0.0", default
 filecoin-hashers = { version = "~7.0.0", default-features = false, features = ["poseidon", "sha256"] }
 fr32 = { version = "~5.0.0", default-features = false }
 storage-proofs-core = { version = "~12.0.0", default-features = false }
-storage-proofs-porep = { version = "~12.0.0", default-features = false }
 
 [features]
 default = ["opencl"]
-cuda = ["filecoin-proofs-v1/cuda", "filecoin-hashers/cuda", "storage-proofs-core/cuda", "storage-proofs-porep/cuda", "bellperson/cuda"]
-opencl = ["filecoin-proofs-v1/opencl", "filecoin-hashers/opencl", "storage-proofs-core/opencl", "storage-proofs-porep/opencl", "bellperson/opencl"]
-multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
+cuda = ["filecoin-proofs-v1/cuda", "filecoin-hashers/cuda", "storage-proofs-core/cuda", "bellperson/cuda"]
+opencl = ["filecoin-proofs-v1/opencl", "filecoin-hashers/opencl", "storage-proofs-core/opencl", "bellperson/opencl"]
+multicore-sdr = ["filecoin-proofs-v1/multicore-sdr"]


### PR DESCRIPTION
There is a dependency on `storage-proofs-porep`, but it isn't used anywhere in the source. I suspect that it was included in order to enable the `multicore-sdr` feature. But this feature can also be enabled through setting it on `filecoin-proofs-v1`, which will then set it on `storage-proofs-porep`. The same is true for the `cuda` and `opencl` features.