### PR TITLE
feat: enable CUDA by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,39 @@ executors:
 
 jobs:
   test:
-    executor: linux
+    # The tests need CUDA, hence use a different docker image.
+    docker:
+      - image: nvidia/cuda:12.0.1-devel-ubuntu22.04
+    resource_class: small
     environment:
       RUST_LOG: trace
+      # Build the kernel only for the single architecture . This should reduce
+      # the overall compile-time significantly.
+      EC_GPU_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
+      BELLMAN_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
+      NEPTUNE_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
     steps:
       - checkout
       - run:
           name: Install requirements
           command: |
-            sudo apt update
-            sudo apt install ocl-icd-opencl-dev --yes
+            apt update
+            apt install ocl-icd-opencl-dev curl --yes
+      - run:
+          name: Install Rust
+          command: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $(cat rust-toolchain) -y
+      - run:
+          # For some reason `source ~/.cargo.env` does not work.
+          name: Setup environment
+          command: |
+            echo 'export PATH="~/.cargo/bin:${PATH}"' | tee --append ${BASH_ENV}
+            echo 'export LD_LIBRARY_PATH=/usr/local/cuda/compat' | tee --append ${BASH_ENV}
+            source ${BASH_ENV}
+      # Run clippy as apart of the test job as it also needs the nvidia toolkit
+      # in order to compile
+      - run:
+          name: Run cargo clippy
+          command: cargo clippy --workspace -- -D warnings
       - run:
           name: Test
           command: cargo test --verbose
@@ -29,14 +52,6 @@ jobs:
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
-
-  clippy:
-    executor: linux
-    steps:
-      - checkout
-      - run:
-          name: Run cargo clippy
-          command: cargo clippy --workspace -- -D warnings
 
   test_darwin:
     macos:
@@ -56,13 +71,13 @@ jobs:
             source ${HOME}/.cargo/env
       - run:
           name: Test (Darwin)
-          command: cargo test --release --verbose
+          # CUDA isn't support on MacOS, hence only enable OpenCL.
+          command: cargo test --release --verbose --no-default-features --features opencl
 
 workflows:
   version: 2.1
   test_all:
     jobs:
       - rustfmt
-      - clippy
       - test
       - test_darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+- Enable CUDA by default [#81](https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/76)
+
 ## [12.0.0] - 2022-08-04
 
 - Update to latest Proofs and dependencies [#76](https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/76)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ fr32 = { version = "~5.0.0", default-features = false }
 storage-proofs-core = { version = "~12.0.0", default-features = false }
 
 [features]
-default = ["opencl"]
+default = ["opencl", "cuda"]
 cuda = ["filecoin-proofs-v1/cuda", "filecoin-hashers/cuda", "storage-proofs-core/cuda", "bellperson/cuda"]
 opencl = ["filecoin-proofs-v1/opencl", "filecoin-hashers/opencl", "storage-proofs-core/opencl", "bellperson/opencl"]
 multicore-sdr = ["filecoin-proofs-v1/multicore-sdr"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library is meant to be the official public API into the proofs library.
 
 ## Default build options
 
-The build options enabled by default are `pairing` and `gpu`. An alternative backend that can be used is `blst`. The `pairing` and `blst` options specify which bls12-381 pairing library to use.
+The build options enabled by default are `cuda` and `opencl`.
 
 ## Running the tests
 
@@ -18,16 +18,10 @@ Running the tests with the default features can be done like this:
 cargo test --release --all
 ```
 
-Running with the `blst` and `gpu` features can be done like this:
+Running with the `cuda` feature only can be done like this:
 
 ```
-cargo test --no-default-features --features blst,gpu --release --all
-```
-
-Running with `pairing` and without the `gpu` feature can be done like this:
-
-```
-cargo test --no-default-features --features pairing --release --all
+cargo test --no-default-features --features cuda --release --all
 ```
 
 ## License


### PR DESCRIPTION
Now things are automatically built with CUDA enabled. If your system has a GPU that supports CUDA, it will be used. If there is only a GPU with OpenCL support, then it will fallback to it. If no GPU is available the CPU is used.