### PR TITLE
ci: update macos runner to Apple silicon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
   test_darwin:
     macos:
       xcode: "13.4.1"
-    resource_class: medium
+    resource_class: macos.x86.medium.gen2
     environment:
       RUST_LOG: trace
     steps:


### PR DESCRIPTION
CircleCI is removing support for Apple Intel executors on Oct 2 - see https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. After that date only Apple Silicon executors will be available. This PR ensures the macos builds are executed on Apple Silicon executors only.