### PR TITLE
ci: use gen2 macos executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
   test_darwin:
     macos:
       xcode: "13.4.1"
-    resource_class: medium
+    resource_class: macos.x86.medium.gen2
     environment:
       RUST_LOG: trace
     steps:


### PR DESCRIPTION
This PR ensure the repo continues to build on Apple Intel executors beyond October 2. Gen 1 executors are getting deprecated. See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718.

Alternatively, we can (**should**) migrate directly to Apple Silicon executors since ALL Apple Intel executors are getting deprecated by January 2024. See https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/93