### PR TITLE
ci: switch macos builds to apple silicon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
   test_darwin:
     macos:
       xcode: "13.4.1"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     environment:
       RUST_LOG: trace
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
   test_darwin:
     macos:
       xcode: "13.4.1"
-    resource_class: medium
+    resource_class: macos.x86.medium.gen2
     environment:
       RUST_LOG: trace
     steps:


### PR DESCRIPTION
This PR migrated the macos builds in the repo to Apple Silicon executors since the Apple Intel ones are getting deprecated by January 2024. See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718.