### PR TITLE
fix: remove clear_layer_data call

### DIFF
--- a/src/seal.rs
+++ b/src/seal.rs
@@ -420,18 +420,6 @@ fn generate_synth_proofs_inner<Tree: 'static + MerkleTreeTrait>(
     )
 }
 
-/// Ensure that any persisted layers are discarded.
-///
-/// # Arguments
-///
-/// * `sector_size` - Sector size associated with cache data to clear.
-/// * `cache_path` - Path to directory where cached data is stored.
-pub fn clear_layer_data(sector_size: u64, cache_path: &Path) -> Result<()> {
-    use filecoin_proofs_v1::clear_layer_data;
-
-    with_shape!(sector_size, clear_layer_data, cache_path)
-}
-
 /// Ensure that any persisted synthetic proofs are discarded.
 ///
 /// # Arguments


### PR DESCRIPTION
The `clear_layer_data` call was accidentally introduced with the Synthetic PoRep. The call does under the hood exactly what `clear_cache` is doing. It was already removed from the FFI via [PR 436], so that we can remove it here as well. This reduces the API surface, which is generally a good idea.

[PR 436]: https://github.com/filecoin-project/filecoin-ffi/pull/436

BREAKING CHANGE: `clear_layer_data` was removed, use `clear_cache` instead.