### PR TITLE
feat: add support for Non-interactive PoRep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   linux:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.70
     resource_class: small
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,9 @@ big-tests = []
 # This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
 # setting is ignored, no `TemporaryAux` file will be written.
 fixed-rows-to-discard = ["filecoin-proofs-v1/fixed-rows-to-discard", "storage-proofs-core/fixed-rows-to-discard"]
+
+[patch.crates-io]
+filecoin-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs" }
+filecoin-hashers = { git = "https://github.com/filecoin-project/rust-fil-proofs" }
+fr32 = { git = "https://github.com/filecoin-project/rust-fil-proofs" }
+storage-proofs-core = { git = "https://github.com/filecoin-project/rust-fil-proofs" }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -33,6 +33,12 @@ pub enum RegisteredSealProof {
     StackedDrg512MiBV1_1_Feat_SyntheticPoRep,
     StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
     StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
+
+    StackedDrg2KiBV1_1_Feat_NonInteractivePoRep,
+    StackedDrg8MiBV1_1_Feat_NonInteractivePoRep,
+    StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep,
+    StackedDrg32GiBV1_1_Feat_NonInteractivePoRep,
+    StackedDrg64GiBV1_1_Feat_NonInteractivePoRep,
 }
 
 // This maps all registered seal proof enum types to porep_id values.
@@ -67,6 +73,26 @@ lazy_static! {
         (
             RegisteredSealProof::StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
             14
+        ),
+        (
+            RegisteredSealProof::StackedDrg2KiBV1_1_Feat_NonInteractivePoRep,
+            15
+        ),
+        (
+            RegisteredSealProof::StackedDrg8MiBV1_1_Feat_NonInteractivePoRep,
+            16
+        ),
+        (
+            RegisteredSealProof::StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep,
+            17
+        ),
+        (
+            RegisteredSealProof::StackedDrg32GiBV1_1_Feat_NonInteractivePoRep,
+            18
+        ),
+        (
+            RegisteredSealProof::StackedDrg64GiBV1_1_Feat_NonInteractivePoRep,
+            19
         ),
     ]
     .into_iter()
@@ -121,7 +147,12 @@ impl RegisteredSealProof {
             | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
             | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
             | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
-            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => ApiVersion::V1_1_0,
+            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => ApiVersion::V1_1_0,
         }
     }
 
@@ -144,21 +175,26 @@ impl RegisteredSealProof {
     pub fn sector_size(self) -> SectorSize {
         use RegisteredSealProof::*;
         let size = match self {
-            StackedDrg2KiBV1 | StackedDrg2KiBV1_1 | StackedDrg2KiBV1_1_Feat_SyntheticPoRep => {
-                constants::SECTOR_SIZE_2_KIB
-            }
-            StackedDrg8MiBV1 | StackedDrg8MiBV1_1 | StackedDrg8MiBV1_1_Feat_SyntheticPoRep => {
-                constants::SECTOR_SIZE_8_MIB
-            }
+            StackedDrg2KiBV1
+            | StackedDrg2KiBV1_1
+            | StackedDrg2KiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep => constants::SECTOR_SIZE_2_KIB,
+            StackedDrg8MiBV1
+            | StackedDrg8MiBV1_1
+            | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep => constants::SECTOR_SIZE_8_MIB,
             StackedDrg512MiBV1
             | StackedDrg512MiBV1_1
-            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep => constants::SECTOR_SIZE_512_MIB,
-            StackedDrg32GiBV1 | StackedDrg32GiBV1_1 | StackedDrg32GiBV1_1_Feat_SyntheticPoRep => {
-                constants::SECTOR_SIZE_32_GIB
-            }
-            StackedDrg64GiBV1 | StackedDrg64GiBV1_1 | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
-                constants::SECTOR_SIZE_64_GIB
-            }
+            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep => constants::SECTOR_SIZE_512_MIB,
+            StackedDrg32GiBV1
+            | StackedDrg32GiBV1_1
+            | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep => constants::SECTOR_SIZE_32_GIB,
+            StackedDrg64GiBV1
+            | StackedDrg64GiBV1_1
+            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => constants::SECTOR_SIZE_64_GIB,
         };
         SectorSize(size)
     }
@@ -202,6 +238,13 @@ impl RegisteredSealProof {
                     .get(&constants::SECTOR_SIZE_64_GIB)
                     .expect("invalid sector size")
             }
+            StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
+                constants::get_porep_non_interactive_partitions(self.sector_size().into())
+            }
         }
     }
 
@@ -224,7 +267,12 @@ impl RegisteredSealProof {
             | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
             | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
             | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
-            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
+            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
                 filecoin_proofs_v1::SINGLE_PARTITION_PROOF_LEN
             }
         }
@@ -288,6 +336,20 @@ impl RegisteredSealProof {
                     porep_id: self.porep_id(),
                     api_version: self.version(),
                     api_features: vec![ApiFeature::SyntheticPoRep],
+                }
+            }
+            StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
+                assert_eq!(self.version(), ApiVersion::V1_1_0);
+                PoRepConfig {
+                    sector_size: self.sector_size(),
+                    partitions: PoRepProofPartitions(self.partitions()),
+                    porep_id: self.porep_id(),
+                    api_version: self.version(),
+                    api_features: vec![ApiFeature::NonInteractivePoRep],
                 }
             } // _ => panic!("Can only be called on V1 configs"),
         }
@@ -370,21 +432,26 @@ impl RegisteredSealProof {
         use RegisteredPoStProof::*;
         use RegisteredSealProof::*;
         match self {
-            StackedDrg2KiBV1 | StackedDrg2KiBV1_1 | StackedDrg2KiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWinning2KiBV1
-            }
-            StackedDrg8MiBV1 | StackedDrg8MiBV1_1 | StackedDrg8MiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWinning8MiBV1
-            }
+            StackedDrg2KiBV1
+            | StackedDrg2KiBV1_1
+            | StackedDrg2KiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep => StackedDrgWinning2KiBV1,
+            StackedDrg8MiBV1
+            | StackedDrg8MiBV1_1
+            | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep => StackedDrgWinning8MiBV1,
             StackedDrg512MiBV1
             | StackedDrg512MiBV1_1
-            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep => StackedDrgWinning512MiBV1,
-            StackedDrg32GiBV1 | StackedDrg32GiBV1_1 | StackedDrg32GiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWinning32GiBV1
-            }
-            StackedDrg64GiBV1 | StackedDrg64GiBV1_1 | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWinning64GiBV1
-            }
+            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep => StackedDrgWinning512MiBV1,
+            StackedDrg32GiBV1
+            | StackedDrg32GiBV1_1
+            | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep => StackedDrgWinning32GiBV1,
+            StackedDrg64GiBV1
+            | StackedDrg64GiBV1_1
+            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => StackedDrgWinning64GiBV1,
         }
     }
 
@@ -400,21 +467,26 @@ impl RegisteredSealProof {
         use RegisteredPoStProof::*;
         use RegisteredSealProof::*;
         match self {
-            StackedDrg2KiBV1 | StackedDrg2KiBV1_1 | StackedDrg2KiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWindow2KiBV1_2
-            }
-            StackedDrg8MiBV1 | StackedDrg8MiBV1_1 | StackedDrg8MiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWindow8MiBV1_2
-            }
+            StackedDrg2KiBV1
+            | StackedDrg2KiBV1_1
+            | StackedDrg2KiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep => StackedDrgWindow2KiBV1_2,
+            StackedDrg8MiBV1
+            | StackedDrg8MiBV1_1
+            | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep => StackedDrgWindow8MiBV1_2,
             StackedDrg512MiBV1
             | StackedDrg512MiBV1_1
-            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep => StackedDrgWindow512MiBV1_2,
-            StackedDrg32GiBV1 | StackedDrg32GiBV1_1 | StackedDrg32GiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWindow32GiBV1_2
-            }
-            StackedDrg64GiBV1 | StackedDrg64GiBV1_1 | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
-                StackedDrgWindow64GiBV1_2
-            }
+            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep => StackedDrgWindow512MiBV1_2,
+            StackedDrg32GiBV1
+            | StackedDrg32GiBV1_1
+            | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep => StackedDrgWindow32GiBV1_2,
+            StackedDrg64GiBV1
+            | StackedDrg64GiBV1_1
+            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => StackedDrgWindow64GiBV1_2,
         }
     }
 }
@@ -876,7 +948,7 @@ mod tests {
     use super::*;
     use filecoin_proofs_v1::MAX_LEGACY_REGISTERED_SEAL_PROOF_ID;
 
-    const REGISTERED_SEAL_PROOFS: [RegisteredSealProof; 15] = [
+    const REGISTERED_SEAL_PROOFS: [RegisteredSealProof; 20] = [
         RegisteredSealProof::StackedDrg2KiBV1,
         RegisteredSealProof::StackedDrg8MiBV1,
         RegisteredSealProof::StackedDrg512MiBV1,
@@ -892,6 +964,11 @@ mod tests {
         RegisteredSealProof::StackedDrg512MiBV1_1_Feat_SyntheticPoRep,
         RegisteredSealProof::StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
         RegisteredSealProof::StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
+        RegisteredSealProof::StackedDrg2KiBV1_1_Feat_NonInteractivePoRep,
+        RegisteredSealProof::StackedDrg8MiBV1_1_Feat_NonInteractivePoRep,
+        RegisteredSealProof::StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep,
+        RegisteredSealProof::StackedDrg32GiBV1_1_Feat_NonInteractivePoRep,
+        RegisteredSealProof::StackedDrg64GiBV1_1_Feat_NonInteractivePoRep,
     ];
 
     #[test]
@@ -948,6 +1025,21 @@ mod tests {
             RegisteredSealProof::StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
                 "0e00000000000000000000000000000000000000000000000000000000000000"
             }
+            RegisteredSealProof::StackedDrg2KiBV1_1_Feat_NonInteractivePoRep => {
+                "0f00000000000000000000000000000000000000000000000000000000000000"
+            }
+            RegisteredSealProof::StackedDrg8MiBV1_1_Feat_NonInteractivePoRep => {
+                "1000000000000000000000000000000000000000000000000000000000000000"
+            }
+            RegisteredSealProof::StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep => {
+                "1100000000000000000000000000000000000000000000000000000000000000"
+            }
+            RegisteredSealProof::StackedDrg32GiBV1_1_Feat_NonInteractivePoRep => {
+                "1200000000000000000000000000000000000000000000000000000000000000"
+            }
+            RegisteredSealProof::StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
+                "1300000000000000000000000000000000000000000000000000000000000000"
+            }
         };
         let hex: String = rsp
             .porep_id()
@@ -985,7 +1077,12 @@ mod tests {
                 | RegisteredSealProof::StackedDrg8MiBV1_1_Feat_SyntheticPoRep
                 | RegisteredSealProof::StackedDrg512MiBV1_1_Feat_SyntheticPoRep
                 | RegisteredSealProof::StackedDrg32GiBV1_1_Feat_SyntheticPoRep
-                | RegisteredSealProof::StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
+                | RegisteredSealProof::StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+                | RegisteredSealProof::StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+                | RegisteredSealProof::StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+                | RegisteredSealProof::StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+                | RegisteredSealProof::StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+                | RegisteredSealProof::StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
                     assert!(!is_legacy)
                 }
             }

--- a/src/seal.rs
+++ b/src/seal.rs
@@ -54,7 +54,10 @@ impl Labels {
         use std::any::Any;
         use RegisteredSealProof::*;
         match proof {
-            StackedDrg2KiBV1 | StackedDrg2KiBV1_1 | StackedDrg2KiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg2KiBV1
+            | StackedDrg2KiBV1_1
+            | StackedDrg2KiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(labels) = <dyn Any>::downcast_ref::<RawLabels<SectorShape2KiB>>(labels)
                 {
                     Ok(Labels::StackedDrg2KiBV1(labels.clone()))
@@ -62,7 +65,10 @@ impl Labels {
                     bail!("invalid labels provided")
                 }
             }
-            StackedDrg8MiBV1 | StackedDrg8MiBV1_1 | StackedDrg8MiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg8MiBV1
+            | StackedDrg8MiBV1_1
+            | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(labels) = <dyn Any>::downcast_ref::<RawLabels<SectorShape8MiB>>(labels)
                 {
                     Ok(Labels::StackedDrg8MiBV1(labels.clone()))
@@ -72,7 +78,8 @@ impl Labels {
             }
             StackedDrg512MiBV1
             | StackedDrg512MiBV1_1
-            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep => {
+            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep => {
                 if let Some(labels) =
                     <dyn Any>::downcast_ref::<RawLabels<SectorShape512MiB>>(labels)
                 {
@@ -81,7 +88,10 @@ impl Labels {
                     bail!("invalid labels provided")
                 }
             }
-            StackedDrg32GiBV1 | StackedDrg32GiBV1_1 | StackedDrg32GiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg32GiBV1
+            | StackedDrg32GiBV1_1
+            | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(labels) = <dyn Any>::downcast_ref::<RawLabels<SectorShape32GiB>>(labels)
                 {
                     Ok(Labels::StackedDrg32GiBV1(labels.clone()))
@@ -89,7 +99,10 @@ impl Labels {
                     bail!("invalid labels provided")
                 }
             }
-            StackedDrg64GiBV1 | StackedDrg64GiBV1_1 | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg64GiBV1
+            | StackedDrg64GiBV1_1
+            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(labels) = <dyn Any>::downcast_ref::<RawLabels<SectorShape64GiB>>(labels)
                 {
                     Ok(Labels::StackedDrg64GiBV1(labels.clone()))
@@ -185,7 +198,10 @@ impl VanillaSealProof {
         use std::any::Any;
         use RegisteredSealProof::*;
         match proof {
-            StackedDrg2KiBV1 | StackedDrg2KiBV1_1 | StackedDrg2KiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg2KiBV1
+            | StackedDrg2KiBV1_1
+            | StackedDrg2KiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(proofs) = <dyn Any>::downcast_ref::<
                     Vec<Vec<RawVanillaSealProof<SectorShape2KiB>>>,
                 >(proofs)
@@ -195,7 +211,10 @@ impl VanillaSealProof {
                     bail!("invalid proofs provided")
                 }
             }
-            StackedDrg8MiBV1 | StackedDrg8MiBV1_1 | StackedDrg8MiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg8MiBV1
+            | StackedDrg8MiBV1_1
+            | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(proofs) = <dyn Any>::downcast_ref::<
                     Vec<Vec<RawVanillaSealProof<SectorShape8MiB>>>,
                 >(proofs)
@@ -207,7 +226,8 @@ impl VanillaSealProof {
             }
             StackedDrg512MiBV1
             | StackedDrg512MiBV1_1
-            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep => {
+            | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep => {
                 if let Some(proofs) = <dyn Any>::downcast_ref::<
                     Vec<Vec<RawVanillaSealProof<SectorShape512MiB>>>,
                 >(proofs)
@@ -217,7 +237,10 @@ impl VanillaSealProof {
                     bail!("invalid proofs provided")
                 }
             }
-            StackedDrg32GiBV1 | StackedDrg32GiBV1_1 | StackedDrg32GiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg32GiBV1
+            | StackedDrg32GiBV1_1
+            | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(proofs) = <dyn Any>::downcast_ref::<
                     Vec<Vec<RawVanillaSealProof<SectorShape32GiB>>>,
                 >(proofs)
@@ -227,7 +250,10 @@ impl VanillaSealProof {
                     bail!("invalid proofs provided")
                 }
             }
-            StackedDrg64GiBV1 | StackedDrg64GiBV1_1 | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
+            StackedDrg64GiBV1
+            | StackedDrg64GiBV1_1
+            | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+            | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
                 if let Some(proofs) = <dyn Any>::downcast_ref::<
                     Vec<Vec<RawVanillaSealProof<SectorShape64GiB>>>,
                 >(proofs)
@@ -1741,7 +1767,12 @@ pub fn generate_piece_commitment<T: Read>(
         | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
         | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
         | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
-        | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
+        | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+        | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+        | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
             filecoin_proofs_v1::generate_piece_commitment(source, piece_size)
         }
     }
@@ -1797,7 +1828,12 @@ where
         | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
         | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
         | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
-        | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
+        | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+        | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+        | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
             filecoin_proofs_v1::add_piece(source, target, piece_size, piece_lengths)
         }
     }
@@ -1846,7 +1882,12 @@ where
         | StackedDrg8MiBV1_1_Feat_SyntheticPoRep
         | StackedDrg512MiBV1_1_Feat_SyntheticPoRep
         | StackedDrg32GiBV1_1_Feat_SyntheticPoRep
-        | StackedDrg64GiBV1_1_Feat_SyntheticPoRep => {
+        | StackedDrg64GiBV1_1_Feat_SyntheticPoRep
+        | StackedDrg2KiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg8MiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg512MiBV1_1_Feat_NonInteractivecPoRep
+        | StackedDrg32GiBV1_1_Feat_NonInteractivePoRep
+        | StackedDrg64GiBV1_1_Feat_NonInteractivePoRep => {
             filecoin_proofs_v1::write_and_preprocess(source, target, piece_size)
         }
     }


### PR DESCRIPTION
This commit introduces new registered proof types in order to support ni-porep.

Also Rust >= 1.70 is needed due to the dependency on `home` v0.5.9.