### PR TITLE
refactor: use newly exported types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,19 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.26"
-bellperson = { version = "0.26", default-features = false }
 bincode = "1.1.2"
 blstrs = "0.7"
 lazy_static = "1.2"
 serde = "1.0.104"
 filecoin-proofs-v1 = { package = "filecoin-proofs", version = "~18.0.0", default-features = false }
-filecoin-hashers = { version = "~12.0.0", default-features = false, features = ["poseidon", "sha256"] }
 fr32 = { version = "~10.0.0", default-features = false }
 storage-proofs-core = { version = "~18.0.0", default-features = false }
 
 [features]
 default = ["opencl", "cuda"]
-cuda = ["filecoin-proofs-v1/cuda", "filecoin-hashers/cuda", "storage-proofs-core/cuda", "bellperson/cuda"]
-cuda-supraseal = ["filecoin-proofs-v1/cuda-supraseal", "filecoin-hashers/cuda", "storage-proofs-core/cuda-supraseal", "bellperson/cuda-supraseal"]
-opencl = ["filecoin-proofs-v1/opencl", "filecoin-hashers/opencl", "storage-proofs-core/opencl", "bellperson/opencl"]
+cuda = ["filecoin-proofs-v1/cuda", "storage-proofs-core/cuda"]
+cuda-supraseal = ["filecoin-proofs-v1/cuda-supraseal", "storage-proofs-core/cuda-supraseal"]
+opencl = ["filecoin-proofs-v1/opencl", "storage-proofs-core/opencl"]
 multicore-sdr = ["filecoin-proofs-v1/multicore-sdr"]
 big-tests = []
 # This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,9 @@ pub use filecoin_proofs_v1::types::{
 pub use filecoin_proofs_v1::{FallbackPoStSectorProof, SnarkProof, VanillaProof};
 pub use fr32;
 pub use storage_proofs_core::{
-    api_version::{ApiFeature, ApiVersion},
+    api_version::{AggregateVersion, ApiFeature, ApiVersion},
     error::Error as StorageProofsError,
-    merkle::MerkleTreeTrait,
+    merkle::{Hasher, MerkleTreeTrait},
     parameter_cache::{get_parameter_data, get_verifying_key_data},
     sector::{OrderedSectorSet, SectorId},
     util::NODE_SIZE,

--- a/src/seal.rs
+++ b/src/seal.rs
@@ -4,9 +4,7 @@ use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, ensure, Error, Result};
-use bellperson::groth16::aggregate::AggregateVersion;
 use blstrs::Scalar as Fr;
-use filecoin_hashers::Hasher;
 
 use filecoin_proofs_v1::constants::{
     SectorShape16KiB, SectorShape16MiB, SectorShape1GiB, SectorShape2KiB, SectorShape32GiB,
@@ -20,8 +18,9 @@ use filecoin_proofs_v1::{with_shape, Labels as RawLabels};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AggregateSnarkProof, ApiFeature, Commitment, PieceInfo, ProverId, RegisteredAggregationProof,
-    RegisteredSealProof, SectorId, Ticket, UnpaddedByteIndex, UnpaddedBytesAmount,
+    AggregateSnarkProof, AggregateVersion, ApiFeature, Commitment, Hasher, PieceInfo, ProverId,
+    RegisteredAggregationProof, RegisteredSealProof, SectorId, Ticket, UnpaddedByteIndex,
+    UnpaddedBytesAmount,
 };
 
 /// The output of [`seal_pre_commit_phase1`].


### PR DESCRIPTION
`storage_proofs_core` exports more commonly used types in newer released versions. This way we don't need to have a direct dependency on `bellperson` and `filecoin_hashers` anymore. This lowers the maintenance burden in case of new released. It also simplifies the feature handling, as we don't need to explicitly enable features on `filecoin_hashers` and `bellperson`.