### PR TITLE
Revert "feat: test out self hosted runner"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,17 @@ env:
 
 jobs:
   check_clippy:
-#    runs-on: ubuntu-24.04
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     name: Clippy
     steps:
       - uses: actions/checkout@v4
-#      - name: Install required packages
-#        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+      - name: Install required packages
+        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
       - name: Run cargo clippy
         run: cargo clippy --all-targets --workspace -- -D warnings
 
   check_fmt:
-#    runs-on: ubuntu-24.04
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     name: Checking fmt
     steps:
       - uses: actions/checkout@v4
@@ -42,13 +40,12 @@ jobs:
         run: cargo fmt --all -- --check
 
   test:
-#    runs-on: ubuntu-24.04
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     name: Test
     steps:
       - uses: actions/checkout@v4
-#      - name: Install required packages
-#        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+      - name: Install required packages
+        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
       # In case no GPUs are available, it's using the CPU fallback.
       - name: Test
         run: cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install required packages
         run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+      - name: Install cargo clippy
+        run: rustup component add clippy
       - name: Run cargo clippy
         run: cargo clippy --all-targets --workspace -- -D warnings
 
@@ -36,6 +38,8 @@ jobs:
     name: Checking fmt
     steps:
       - uses: actions/checkout@v4
+      - name: Install cargo fmt
+        run: rustup component add rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
Reverts filecoin-project/rust-filecoin-proofs-api#105

This is related to https://github.com/filecoin-project/github-mgmt/issues/132. This is a temporary revert. We need to first get back on hosted runners before getting on FilOz's self-hosted runners, because `self-hosted` tag is too permissive and would start matching any FilOz's runners as soon as I allow this repository to access them. 