### PR TITLE
ci: create release workflow that uses cargo release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  # TODO: Remove this after testing
+  push:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run'
+        required: true
+        default: true
+        type: boolean
+      level:
+        description: 'Release level'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # The permissions should allow the user to:
+    # 1. Push to the branch of the repository that triggered the workflow.
+    # 2. Create a tag.
+    # 3. Push to crates.io.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install required packages
+        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+      - name: Install cargo release
+        run: cargo install --version 0.25.17 cargo-release
+      - name: Run cargo release
+        # TODO: Uncomment this after testing
+        # run: cargo release ${{ (!github.event.inputs.dry_run) && '--execute' || '' }} --no-confirm ${{ github.event.inputs.level }}
+        # TODO: Remove this after testing
+        run: cargo release major

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,8 @@
 name: Release
 
 on:
-  # TODO: Remove this after testing
-  push:
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: 'Dry run'
-        required: true
-        default: true
-        type: boolean
       level:
         description: 'Release level'
         required: true
@@ -41,10 +34,9 @@ jobs:
         run: cargo install --version 0.25.17 cargo-release
       - name: Set git user
         run: |
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com>"
-          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_TRIGGERING_ACTOR}@users.noreply.github.com>"
+          git config --global user.name "${GITHUB_TRIGGERING_ACTOR}"
       - name: Run cargo release
-        # TODO: Uncomment this after testing
-        # run: cargo release ${{ github.event.inputs.level }} ${{ github.event.inputs.dry_run && '--no-push' || '' }} ${{ github.event.inputs.dry_run && '--no-publish' || '' }} --no-confirm --execute
-        # TODO: Remove this after testing
-        run: cargo release major --no-push --no-publish --no-confirm --execute
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo release ${{ github.event.inputs.level }} --no-confirm --execute

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,6 @@ jobs:
         run: cargo install --version 0.25.17 cargo-release
       - name: Run cargo release
         # TODO: Uncomment this after testing
-        # run: cargo release ${{ (!github.event.inputs.dry_run) && '--execute' || '' }} --no-confirm ${{ github.event.inputs.level }}
+        # run: cargo release ${{ github.event.inputs.level }} ${{ github.event.inputs.dry_run && '--no-push' || '' }} ${{ github.event.inputs.dry_run && '--no-publish' || '' }} --no-confirm --execute
         # TODO: Remove this after testing
-        run: cargo release major
+        run: cargo release major --no-push --no-publish --no-confirm --execute

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,14 @@ defaults:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # The permissions should allow the user to:
-    # 1. Push to the branch of the repository that triggered the workflow.
-    # 2. Create a tag.
-    # 3. Push to crates.io.
     permissions:
+      # The contents write should allow:
+      # 1. Push to the branch of the repository that triggered the workflow.
+      # 2. Create a tag.
+      # 3. Push to crates.io.
       contents: write
+      # The id-token write should allow the OIDC token exchange
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Install required packages
@@ -34,9 +36,11 @@ jobs:
         run: cargo install --version 0.25.17 cargo-release
       - name: Set git user
         run: |
-          git config --global user.email "${GITHUB_TRIGGERING_ACTOR}@users.noreply.github.com>"
+          git config --global user.email "${GITHUB_TRIGGERING_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_TRIGGERING_ACTOR}"
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Run cargo release
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo release ${{ github.event.inputs.level }} --no-confirm --execute

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ on:
           - minor
           - major
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -35,6 +39,10 @@ jobs:
         run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
       - name: Install cargo release
         run: cargo install --version 0.25.17 cargo-release
+      - name: Set git user
+        run: |
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com>"
+          git config --global user.name "${GITHUB_ACTOR}"
       - name: Run cargo release
         # TODO: Uncomment this after testing
         # run: cargo release ${{ github.event.inputs.level }} ${{ github.event.inputs.dry_run && '--no-push' || '' }} ${{ github.event.inputs.dry_run && '--no-publish' || '' }} --no-confirm --execute

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ bincode = "1.1.2"
 blstrs = "0.7"
 lazy_static = "1.2"
 serde = "1.0.104"
-filecoin-proofs-v1 = { package = "filecoin-proofs", version = "~18.1.0", default-features = false }
-fr32 = { version = "~11.1.0", default-features = false }
-storage-proofs-core = { version = "~18.1.0", default-features = false }
+filecoin-proofs-v1 = { package = "filecoin-proofs", version = "~19.0.0", default-features = false }
+fr32 = { version = "~12.0.0", default-features = false }
+storage-proofs-core = { version = "~19.0.0", default-features = false }
 
 [features]
 default = ["opencl", "cuda"]


### PR DESCRIPTION
This adds `release` workflow that can be triggered manually which performs the release using `cargo release`. It requires `CARGO_REGISTRY_TOKEN` to be set in the repository secrets. The token has to be for one of the users that belong to the [proofs-crate-owners](https://github.com/filecoin-project/github-mgmt/blob/master/github/filecoin-project.yml#L5079) team or [filecoin-crate-owner](https://crates.io/users/filecoin-crate-owner).