### PR TITLE
[WIP] ci: set up trusted publishing for the existing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,15 @@ jobs:
       # 2. Create a tag.
       # 3. Push to crates.io.
       contents: write
-      # The id-token write should allow the OIDC token exchange
-      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install required packages
-        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+        run: sudo apt install --no-install-recommends --yes libhwloc-dev ocl-icd-opencl-dev nvidia-cuda-toolkit
       - name: Install cargo release
         run: cargo install --version 0.25.17 cargo-release
       - name: Set git user
         run: |
           git config --global user.email "${GITHUB_TRIGGERING_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_TRIGGERING_ACTOR}"
-      - uses: rust-lang/crates-io-auth-action@v1
-        id: auth
       - name: Run cargo release
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo release ${{ github.event.inputs.level }} --no-confirm --execute

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+# Releasing
+
+## Prepare
+
+To propose a new release, ensure the "Unreleased" section in the [`CHANGELOG.md`](https://github.com/filecoin-project/rust-filecoin-proofs-api/blob/master/CHANGELOG.md) is up-to-date.
+
+## Release
+
+Once the release is prepared, a repo owner will:
+
+1. Trigger the `Release` GitHub Action workflow with appropriate level (`patch`, `minor`, `major`).
+2. The **Release** GitHub Action workflow will automatically:
+   * Create the git tag (`vX.Y.Z`).
+   * Update the CHANGELOG.md, create a git commit and push it to the repository.
+   * Publish the crate to [crates.io](https://crates.io) using `cargo publish`.
+     - Note: This repository uses **trusted publishing** via OIDC. No `CARGO_REGISTRY_TOKEN` secret is required, but the repository must be configured as a trusted publisher on crates.io.
+
+3. Verify the releases on crates.io:
+   https://crates.io/crates/filecoin-proofs-api/versions


### PR DESCRIPTION
_NOTE_: We should decide whether we want to follow the release process proposed here or in https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/114.

This PR documents the release process currently followed in this repo and updates the release workflow to use trusted publishing instead of repository secrets.

TODO: Set up trusted publishing for release.yml workflow.